### PR TITLE
hot-fix for tabs in rtl mode for some themes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,4 +3,8 @@
 	body {
 		direction: ltr;
 	}
+
+	.CodeMirror-code, .CodeMirror-linenumber, .cm-formatting {
+        font-family: var(--font-monospace) !important;
+	} 
 }

--- a/styles.css
+++ b/styles.css
@@ -3,8 +3,9 @@
 	body {
 		direction: ltr;
 	}
-
-	.CodeMirror-code, .CodeMirror-linenumber, .cm-formatting {
-        font-family: var(--font-monospace) !important;
-	} 
+	
+	span.cm-tab {
+		width: 50px !important;
+		display: inline-block;
+	}
 }


### PR DESCRIPTION
Hey, 
I added some css to fix an issue with tabs of some themes in rtl mood. 

# Before 
![image](https://user-images.githubusercontent.com/9850722/113510095-40663480-9559-11eb-87e3-22fdf852b283.png)

# After
![image](https://user-images.githubusercontent.com/9850722/113510103-49570600-9559-11eb-9de3-ed4f4783141d.png)

Best regards.