### PR TITLE
fix: auto direction behavior on tables

### DIFF
--- a/AutoDirPostProcessor.ts
+++ b/AutoDirPostProcessor.ts
@@ -106,11 +106,10 @@ function dirClass(dir: Direction): string {
 }
 
 function addDirClassIfNotAddedBefore(el: HTMLElement, cls: string) {
-	if (el.hasClass('esm-rtl') || el.hasClass('esm-ltr')) {
-		return;
+	if (!el.hasClass(cls)) {
+		el.removeClass('esm-rtl', 'esm-ltr');
+		el.addClass(cls);
 	}
-
-	el.addClass(cls);
 }
 
 function nonSpecialParent(el: HTMLElement) {

--- a/styles.css
+++ b/styles.css
@@ -16,7 +16,8 @@
 }
 
 /* List indent fix */
-.is-mobile .is-rtl .HyperMD-list-line, .is-mobile .HyperMD-list-line[dir="rtl"] {
+.is-mobile .is-rtl .HyperMD-list-line,
+.is-mobile .HyperMD-list-line[dir="rtl"] {
 	text-indent: 0px !important;
 	padding-left: 0 !important;
 }
@@ -127,7 +128,8 @@
 
 .markdown-preview-view.is-auto .esm-rtl,
 .kanban-plugin__board .esm-rtl,
-.kanban-plugin__drag-container .esm-rtl {
+.kanban-plugin__drag-container .esm-rtl,
+.markdown-source-view.is-auto .table-cell-wrapper.esm-rtl {
 	direction: rtl;
 	text-align: right;
 }
@@ -189,6 +191,17 @@ This the collapse indicator will be over the heading text */
 .markdown-preview-view.is-auto .esm-ltr {
 	direction: ltr;
 	text-align-last: left;
+}
+
+/* If table first header is rtl render table on the right side of page but dont
+* make every cell rtl*/
+.cm-table-widget:has(thead tr:first-of-type th:first-of-type .table-cell-wrapper.esm-rtl), 
+.cm-table-widget:has(thead tr:first-of-type th:first-of-type .table-cell-wrapper .cm-line[dir="rtl"]) {
+	direction: rtl;
+}
+.cm-table-widget:has(thead tr:first-of-type th:first-of-type .table-cell-wrapper.esm-rtl) .table-wrapper, 
+.cm-table-widget:has(thead tr:first-of-type th:first-of-type .table-cell-wrapper .cm-line[dir="rtl"]) .table-wrapper {
+	direction: ltr;
 }
 
 /* Helper styles for debugging */


### PR DESCRIPTION
## Fixes
- it considers table rtl (renders table in right side) if the first cell in table head is rtl
- on each cell we have auto direction detection as we have on normal obsidian lines
- problem on cell direction not updating 

Note that the last problem was due to my presupposition that the cell is not editable in post-processing (reading view) and direction would not change. But obsidian renders the table as we are in reading view so every time the table cell changes the reading view of the table updates and we have to check directions.

## What it doesn't fix :(
- Movement between table cells doesn't work correctly when one cell is rtl

related to #70