### PR TITLE
fix: prevent child changing parent element dir

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  transform: {'^.+\\.ts?$': 'ts-jest'},
+  // testRegex: '/tests/.*\\.(test|spec)?\\.(ts|tsx)$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'mjs', 'node']
+};

--- a/package.json
+++ b/package.json
@@ -6,21 +6,25 @@
   "scripts": {
     "dev": "node esbuild.config.mjs",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-    "version": "node version-bump.mjs && git add manifest.json versions.json"
+    "version": "node version-bump.mjs && git add manifest.json versions.json",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "devDependencies": {
     "@codemirror/view": "^6.7.3",
+    "@jest/globals": "^29.7.0",
     "@types/node": "^16.11.6",
     "@typescript-eslint/eslint-plugin": "5.29.0",
     "@typescript-eslint/parser": "5.29.0",
     "builtin-modules": "3.3.0",
     "codemirror": "^6.0.1",
     "esbuild": "0.14.47",
+    "jest-environment-jsdom": "^29.7.0",
     "obsidian": "latest",
     "prettier": "^2.7.1",
+    "ts-jest": "^29.1.2",
     "tslib": "2.4.0",
     "typescript": "4.7.4"
   }

--- a/tests/AutoDirPostProcessor.test.ts
+++ b/tests/AutoDirPostProcessor.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "@jest/globals";
+import { autoDirectionPostProcessor } from "../AutoDirPostProcessor";
+
+describe("AutoDirPostProcessor", () => {
+  test("special node should not change parent element direction if there is text with decidable direction before", () => {
+    const rtlHTML = convertToHTMLElement(
+      `<div><p>سلام، <em>Hello</em></p></div>`,
+    );
+    autoDirectionPostProcessor(rtlHTML, null, null);
+    expect(rtlHTML.outerHTML).toBe(
+      `<div><p class="esm-rtl">سلام، <em>Hello</em></p></div>`,
+    );
+
+    const ltrHTML = convertToHTMLElement(
+      `<div><p>Hello, <em>سلام</em></p></div>`,
+    );
+    autoDirectionPostProcessor(ltrHTML, null, null);
+    expect(ltrHTML.outerHTML).toBe(
+      `<div><p class="esm-ltr">Hello, <em>سلام</em></p></div>`,
+    );
+  });
+
+  test("special node should change parent element direction if there isn't text with decidable direction before", () => {
+    const html = convertToHTMLElement(`<div><p>[<em>سلام</em></p>]</div>`);
+    autoDirectionPostProcessor(html, null, null);
+    expect(html.outerHTML).toBe(
+      `<div><p class="esm-rtl">[<em>سلام</em></p>]</div>`,
+    );
+  });
+});
+
+function convertToHTMLElement(str: string): HTMLElement {
+  const template = document.createElement("template");
+  template.innerHTML = str;
+  return template.content.firstChild as HTMLElement;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,10 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "esModuleInterop": true,
     "lib": [
       "dom",
-	  "DOM.Iterable",
+      "DOM.Iterable",
       "es6",
       "scripthost",
       "es2015"


### PR DESCRIPTION
special nodes should change parent element direction if the parent does not contain any preceding text before the special node.
also added tests for this specific bug.

resolves #77 