### PR TITLE
Add an option and fix 2 bugs related to table editing and status bar indicator

### DIFF
--- a/EditorPlugin.ts
+++ b/EditorPlugin.ts
@@ -6,7 +6,8 @@ import {
 	ViewUpdate,
 	ViewPlugin,
 } from "@codemirror/view";
-import { RangeSetBuilder } from "@codemirror/state";
+import { EditorState, RangeSetBuilder } from "@codemirror/state";
+import { syntaxTree } from "@codemirror/language";
 import RtlPlugin from './main';
 import { editorInfoField, MarkdownView } from 'obsidian';
 import { Direction } from './direction.util';
@@ -17,6 +18,8 @@ type DecorationRegion = Region & {dec: Decoration};
 export interface EditorPlugin extends PluginValue {
 	setDirection(direction: Direction, view: EditorView): void;
 }
+
+const FRONTMATTER_OPEN = "---";
 
 export function getEditorPlugin(rtlPlugin: RtlPlugin) {
 	return ViewPlugin.fromClass(
@@ -38,11 +41,25 @@ export function getEditorPlugin(rtlPlugin: RtlPlugin) {
 			emptyDirDec = Decoration.line({
 				attributes: { dir: "auto" },
 			});
+			
+			// Cached frontmatter range, recalculating only occurs when there is a document change within the range, or
+			// within the first three characters on the first line.
+			// If any, "from" should be 0, and "to" should be the end offset of the line where the frontmatter being closed.
+			// If it doesn't exist, the range should be null.
+			frontmatterRange: { from: number, to: number } | null = null;
 
 			constructor(view: EditorView) {
-				this.decorations = this.buildDecorations(view);
 				this.rtlPlugin = rtlPlugin;
+				this.decorations = this.buildDecorations(view);
 				this.view = view;
+
+				// Get the frontmatter range at initialization if any.
+				let preventRTLFrontmatter = this.rtlPlugin.settings.preventRTLFrontmatter,
+					state = view.state;
+				if (preventRTLFrontmatter && this.checkFrontmatter(state)) {
+					this.getFrontmatterRange(state);
+				}
+
 				const editorInfo = this.view.state.field(editorInfoField);
 				// Checking for editorInfo.editMode because apparently editorInfo.editor which is needed later
 				// is a getter which counts on this field to exist
@@ -54,6 +71,21 @@ export function getEditorPlugin(rtlPlugin: RtlPlugin) {
 
 			update(vu: ViewUpdate) {
 				if (vu.viewportChanged || vu.docChanged) {
+
+					// Frontmatter checking
+					if (rtlPlugin.settings.preventRTLFrontmatter && vu.docChanged) {
+						let { from, to } = this.frontmatterRange ?? { from: 0, to: 3 },
+							state = vu.state;
+						// Update this.frontmatterRange only when document change occur within it.
+						if (vu.changes.touchesRange(from, to)) {
+							if (this.checkFrontmatter(state)) {
+								this.getFrontmatterRange(state);
+							} else {
+								this.frontmatterRange = null;
+							}
+						}
+					}
+
 					this.decorations = this.buildDecorations(vu.view);
 				}
 			}
@@ -70,7 +102,16 @@ export function getEditorPlugin(rtlPlugin: RtlPlugin) {
 					decoration = this.direction === 'ltr' ? this.ltrDec : this.rtlDec;
 				}
 
-				for (let pos = viewport.from; pos <= viewport.to; ) {
+				let pos = viewport.from,
+					preventRTLFrontmatter = this.rtlPlugin.settings.preventRTLFrontmatter;
+				// Move the pos after the frontmatter if the pos touches it.
+				if (preventRTLFrontmatter && this.frontmatterRange !== null && pos <= this.frontmatterRange.to) {
+					if (pos == viewport.to)
+						return builder.finish();
+					else pos = this.frontmatterRange.to + 1;
+				}
+
+				while (pos <= viewport.to) {
 					const line = view.state.doc.lineAt(pos);
 					builder.add(line.from, line.from, decoration);
 					pos = line.to + 1;
@@ -83,6 +124,28 @@ export function getEditorPlugin(rtlPlugin: RtlPlugin) {
 			setDirection(direction: Direction, view: EditorView) {
 				this.direction = direction;
 				this.decorations = this.buildDecorations(view);
+			}
+
+			// We notice that frontmatter can exist only if the first line is containing exactly three hyphens ("-")
+			// without any character before or after it, even if it is a space.
+			checkFrontmatter(state: EditorState) {
+				let firstLineStr = state.doc.line(1).text;
+				return firstLineStr == FRONTMATTER_OPEN;
+			}
+
+			// Should be run only when the frontmatter was found.
+			getFrontmatterRange(state: EditorState) {
+				// Using syntax tree to get the range of the frontmatter
+				let treeCursor = syntaxTree(state).cursor(),
+					frontmatterRange = { from: 0, to: 3 };
+				// Need to move twice the cursor first, because the first node is always "Document",
+				// and the second one is the frontmatter opening delimiter.
+				treeCursor.next(); treeCursor.next();
+				while (treeCursor.name.includes("frontmatter")) {
+					frontmatterRange.to = treeCursor.to;
+					treeCursor.next();
+				}
+				this.frontmatterRange = frontmatterRange;
 			}
 
 		}, {decorations: (v) => v.decorations});

--- a/EditorPlugin.ts
+++ b/EditorPlugin.ts
@@ -64,7 +64,20 @@ export function getEditorPlugin(rtlPlugin: RtlPlugin) {
 				// Checking for editorInfo.editMode because apparently editorInfo.editor which is needed later
 				// is a getter which counts on this field to exist
 				if (editorInfo && editorInfo instanceof MarkdownView && (editorInfo as any).editMode) {
-					this.rtlPlugin.adjustDirectionToView(editorInfo, this);
+					// Checking that view is the same as the main document view
+					if ((editorInfo as any).editMode.cm === view) {
+						this.rtlPlugin.adjustDirectionToView(editorInfo, this);
+					}
+					// May be a nested EditorView found in the main view, such as an EditorView of the table cell
+					else {
+						// Retrieving current document direction
+						const file = editorInfo?.file;
+						if (file && file.path) {
+							[this.direction] = this.rtlPlugin.getRequiredFileDirection(file);
+						}
+						// Adjust the direction of the nested view
+						this.setDirection(this.direction, this.view);
+					}
 				}
 				this.rtlPlugin.handleIframeEditor(this.view.dom, this.view, editorInfo.file, this);
 			}

--- a/main.ts
+++ b/main.ts
@@ -38,13 +38,6 @@ export default class RtlPlugin extends Plugin {
 
 		this.addSettingTab(new RtlSettingsTab(this.app, this));
 
-		this.app.workspace.on('active-leaf-change', async (leaf: WorkspaceLeaf) => {
-			// This creates a redundancy with the flow coming from EditorPlugin, but it seems to be needed
-			// for older versions of Obsidian
-			// this.adjustDirectionToActiveView();
-			// this.updateStatusBar();
-		});
-
 		this.app.workspace.on('file-open', async (file: TFile, ctx?: any) => {
 			// This creates a redundancy with the flow coming from EditorPlugin, but it seems to be needed
 			// for older versions of Obsidian
@@ -87,21 +80,7 @@ export default class RtlPlugin extends Plugin {
 		this.registerEvent(this.app.workspace.on("active-leaf-change", leaf => {
 			let view = leaf.view;
 			if (view instanceof MarkdownView && view.file) {
-				let [direction, usedDefault] = this.getRequiredFileDirection(view.file),
-					directionStr = direction == "auto"
-						? direction
-						: direction.toUpperCase();
-				if (usedDefault) {
-					directionStr = `Default (${directionStr})`;
-				} else if (directionStr == "auto") {
-					directionStr = "Auto";
-				}
-				this.statusBarText.textContent = directionStr;
-				this.statusBarItem.style.display = null;
-			}
-			
-			else {
-				this.hideStatusBar();
+				this.updateStatusBar(view);
 			}
 		}));
 	}
@@ -193,11 +172,11 @@ export default class RtlPlugin extends Plugin {
 		}
 	}
 
-	// Update the direction status bar item according to the active view
-	updateStatusBar() {
+	// Update the direction status bar item according to the given view or the active view
+	updateStatusBar(view?: MarkdownView) {
 		let hide = true;
 		let usedDefault = false;
-		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+		if (!view) view = this.app.workspace.getActiveViewOfType(MarkdownView);
 		if (view && view?.editor) {
 			const direction = this.getDocumentDirection(view.editor, view);
 			// If the file is using the settings default direction (i.e. there is no special setting for that

--- a/main.ts
+++ b/main.ts
@@ -308,6 +308,17 @@ export default class RtlPlugin extends Plugin {
 			if (dispatchUpdate)
 				editorView.dispatch();
 		}
+
+		let editor = this.app.workspace.activeEditor?.editor;
+		let activeEditorView = (editor as any)?.activeCM as EditorView;
+		// Check if there any active table cell's EditorView
+		if (activeEditorView && (editor as any).inTableCell as boolean) {
+			// Retrieve EditorPlugin from the table cell view
+			let tableCellEditorPlugin = activeEditorView.plugin(this.editorPlugin);
+			tableCellEditorPlugin.setDirection(newDirection, activeEditorView);
+			// Update the table cell direction
+			activeEditorView.dispatch();
+		}
 	}
 
 	// Set a constant LTR/RTL direction for an editor if required, bypassing Obsidian's default auto direction.

--- a/main.ts
+++ b/main.ts
@@ -80,6 +80,30 @@ export default class RtlPlugin extends Plugin {
 				return;
 			this.switchDocumentDirection(view.editor, view);
 		});
+
+		// Because the indicator button won't show properly the direction text when startup
+		// or when changing between file, we need to register "file-open" view and
+		// set the callback to update the direction text.
+		this.registerEvent(this.app.workspace.on("active-leaf-change", leaf => {
+			let view = leaf.view;
+			if (view instanceof MarkdownView && view.file) {
+				let [direction, usedDefault] = this.getRequiredFileDirection(view.file),
+					directionStr = direction == "auto"
+						? direction
+						: direction.toUpperCase();
+				if (usedDefault) {
+					directionStr = `Default (${directionStr})`;
+				} else if (directionStr == "auto") {
+					directionStr = "Auto";
+				}
+				this.statusBarText.textContent = directionStr;
+				this.statusBarItem.style.display = null;
+			}
+			
+			else {
+				this.hideStatusBar();
+			}
+		}));
 	}
 
 	onunload() {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "license": "MIT",
   "devDependencies": {
     "@codemirror/view": "^6.7.3",
+    "@codemirror/state": "^6.5.2",
+    "@codemirror/language": "^6.10.8",
     "@jest/globals": "^29.7.0",
     "@types/node": "^16.11.6",
     "@typescript-eslint/eslint-plugin": "5.29.0",

--- a/settingsTab.ts
+++ b/settingsTab.ts
@@ -8,6 +8,7 @@ export type Settings = {
 	rememberPerFile: boolean;
 	setNoteTitleDirection: boolean;
 	setYamlDirection: boolean;
+	preventRTLFrontmatter: boolean; // Frontmatter == Raw YAML
 	statusBar: boolean;
 };
 
@@ -17,6 +18,7 @@ export const DEFAULT_SETTINGS: Settings = {
 	rememberPerFile: true,
 	setNoteTitleDirection: true,
 	setYamlDirection: false,
+	preventRTLFrontmatter: false,
 	statusBar: true
 };
 
@@ -81,6 +83,16 @@ export class RtlSettingsTab extends PluginSettingTab {
 							 this.plugin.saveSettings();
 							 this.plugin.adjustDirectionToActiveView();
 						 }));
+
+		new Setting(containerEl)
+			.setName('Prevent raw YAML (Frontmatter) to be RTL-directioned in Editor')
+			.setDesc('Raw YAML will always be LTR-directioned whatever the direction is. (Restart required after changing.)')
+			.addToggle(toggle => toggle.setValue(this.settings.preventRTLFrontmatter ?? false)
+						.onChange((value) => {
+							this.settings.preventRTLFrontmatter = value;
+							this.plugin.saveSettings();
+							this.plugin.adjustDirectionToActiveView();
+						}));
 
 		new Setting(containerEl)
 			.setName('Show status bar item')

--- a/styles.css
+++ b/styles.css
@@ -68,6 +68,11 @@
 	unicode-bidi: unset;
 }
 
+/* Use to force frontmatter to be LTR-directioned when "Prevent Frontmatter to be RTL-directioned" was enabled. */
+.cm-content>.cm-line:has(>.cm-hmd-frontmatter):not([dir]) {
+	direction: ltr;
+}
+
 /* /1* RTL and Auto callout titles that are detected as RTL - set to the right *1/ */
 /* .is-rtl .callout-title:has(.esm-rtl), */
 /* .is-auto .callout-title:has(.esm-rtl) { */


### PR DESCRIPTION
Add an option to prevent the raw YAML to be RTL-directioned, as it was mentioned in the README as one of the known issues.

Also, fix table editing issue #85 and status bar indicator not displayed properly when startup and file changing.