### PR TITLE
docs: calrify front matter direction options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,14 @@ direction: rtl
 ---
 ```
 
-The front matter direction overrides any other setting.
-It is possible to temporarily override a note's direction regardless of the front matter (e.g. to edit or view it differently), but the next time the note is loaded, the front matter direction will always be used.
+Valid vaules for `direction` are:
+
+- `rtl` (right-to-left)
+- `ltr` (left-to-right)
+- `auto` (let Obsidian decide per-line)
+
+The front matter direction **overrides all other settings (including per-file remembered directions).
+While you can temporarily override a note's direction in the UI, the front matter value will always be restored when the note is reloaded.
 
 
 ## Changelog


### PR DESCRIPTION
Following [main.ts](https://github.com/esm7/obsidian-rtl/blob/d9c70f48bd39be86ebd6384521d90c06b1166465/main.ts#L134), I added the available settings options  for frontMatter `direction` and tried to make the text clearer.